### PR TITLE
fix(grille-paiement): permettre la re-soumission après rejet DGA

### DIFF
--- a/features/validation-tickets/grille-de-paiement/components/GrillePaiementContent.tsx
+++ b/features/validation-tickets/grille-de-paiement/components/GrillePaiementContent.tsx
@@ -82,8 +82,14 @@ export default function GrillePaiementContent() {
         </div>
 
         <div className="flex items-center gap-2 self-start sm:self-auto flex-wrap justify-end">
-          {isLotVerrouille && (
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+          {lotStatut && lotStatut !== 'EN_ATTENTE' && (
+            <span
+              className={
+                lotStatut === 'REJETE'
+                  ? 'inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700'
+                  : 'inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700'
+              }
+            >
               <Lock className="h-3 w-3" />
               {lotStatutLabel(lotStatut)}
             </span>

--- a/features/validation-tickets/grille-de-paiement/hooks/use-grille-paiement.ts
+++ b/features/validation-tickets/grille-de-paiement/hooks/use-grille-paiement.ts
@@ -30,7 +30,7 @@ export default function useGrillePaiement() {
   const [ligneAValider, setLigneAValider] = useState<IGrillePaiementLigne | null>(null);
 
   const lotStatut = grille?.lot?.statut;
-  const isLotVerrouille = !!grille?.lot && lotStatut !== 'EN_ATTENTE';
+  const isLotVerrouille = !!grille?.lot && lotStatut !== 'EN_ATTENTE' && lotStatut !== 'REJETE';
 
   const handleCreneauChange = useCallback((id: string | undefined) => {
     setFilters({ creneauId: id ?? '', page: 0 });


### PR DESCRIPTION
## Summary

- Quand le DGA rejette un lot (statut `REJETE`), la vue grille de paiement reste désormais éditable pour le comptable : édition Wave, validation des lignes, et re-soumission via le `SubmitFooter`.
- La pill statut est découplée du gel — elle reste visible pour tout statut post-`EN_ATTENTE`, avec une variante rouge sur `REJETE` (vs amber pour les autres statuts).

Avant : `isLotVerrouille = !!grille?.lot && lotStatut !== 'EN_ATTENTE'` → `REJETE` était considéré comme un statut figé.
Après : `isLotVerrouille = !!grille?.lot && lotStatut !== 'EN_ATTENTE' && lotStatut !== 'REJETE'` → seul un workflow en cours (`CALCUL_EN_COURS`, `SOUMIS_PDG`, `APPROUVE_PDG`, `PAIEMENT_EN_COURS`, `SOLDE`) gèle la vue.

## Test plan

- [ ] Sur `/validation-tickets/grille-de-paiement`, ouvrir un créneau dont le lot est en `REJETE` : pill rouge « Rejeté par le DGA » visible à côté du picker.
- [ ] La table redevient éditable : on peut modifier un numéro Wave et valider une ligne.
- [ ] Le `SubmitFooter` est visible et permet de soumettre à nouveau (`POST /api/creneaux/{id}/soumettre`).
- [ ] Sur un créneau `CALCUL_EN_COURS` (et autres statuts post-EN_ATTENTE), le comportement reste figé comme avant — table read-only, footer caché, pill amber.
- [ ] Sur un créneau `EN_ATTENTE` (jamais soumis), aucune pill, footer présent, table éditable.
- [ ] À confirmer côté back : que `POST /api/creneaux/{id}/soumettre` accepte un re-submit sur un lot `REJETE`. Si non, ouvrir un endpoint dédié `re-soumettre`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)