### PR TITLE
feat(validation-tickets): filtres tableau V2 validés + bouton de rejet sur vérification V1

### DIFF
--- a/components/validation-tickets/verrouillage-v2/verrouillage-v2-content.tsx
+++ b/components/validation-tickets/verrouillage-v2/verrouillage-v2-content.tsx
@@ -20,6 +20,8 @@ export function VerrouillageV2Content() {
     isFetchingNextV2Valide,
     filters,
     setFilters,
+    v2ValideFilters,
+    setV2ValideFilters,
     livreurOptions,
     isLoading,
     fetchNextPage,
@@ -70,6 +72,8 @@ export function VerrouillageV2Content() {
         isValidating={isValidatingAll}
         onValidateAll={handleValidateAll}
       />
+
+      <TicketFilterBar value={v2ValideFilters} onChange={setV2ValideFilters} livreurOptions={livreurOptions} />
 
       <V2ValideTable
         tickets={ticketsV2Valide}

--- a/features/validation-tickets/filters/validation-tickets.filters.ts
+++ b/features/validation-tickets/filters/validation-tickets.filters.ts
@@ -13,3 +13,19 @@ export const validationTicketFiltersOptions = {
   clearOnDefault: true,
   throttleMs: 300,
 } as const;
+
+// Filtres dédiés au tableau « Tickets V2 validés » (bas de page verrouillage-v2).
+// urlKeys préfixés pour éviter toute collision avec les filtres du tableau du haut
+// qui partagent la même page et la même config de parsers.
+export const validationTicketV2ValideFiltersOptions = {
+  clearOnDefault: true,
+  throttleMs: 300,
+  urlKeys: {
+    search: 'v2_search',
+    numero: 'v2_numero',
+    livreurId: 'v2_livreurId',
+    restaurantId: 'v2_restaurantId',
+    debut: 'v2_debut',
+    fin: 'v2_fin',
+  },
+} as const;

--- a/features/validation-tickets/verrouillage-v2/components/TicketReadyCard.tsx
+++ b/features/validation-tickets/verrouillage-v2/components/TicketReadyCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Lock } from 'lucide-react';
+import { Lock, XCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TicketControleV2 } from '../types/tickets-v2.type';
@@ -9,9 +9,10 @@ import { formatCFA } from '@/src/actions/bonLivraison.mapper';
 interface Props {
   ticket: TicketControleV2;
   onLock: (ticketId: string) => void;
+  onReject: (ticketId: string) => void;
 }
 
-export default function TicketReadyCard({ ticket, onLock }: Props) {
+export default function TicketReadyCard({ ticket, onLock, onReject }: Props) {
   return (
     <div className="flex flex-col gap-2 rounded-lg bg-green-50 border border-green-100 px-4 py-3">
       {/* Référence + actions */}
@@ -31,6 +32,15 @@ export default function TicketReadyCard({ ticket, onLock }: Props) {
           >
             <Lock className="h-3 w-3" />
             V1
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => onReject(ticket.commandeId)}
+            className="rounded-full px-4 py-1 text-xs font-semibold flex items-center gap-1.5"
+          >
+            <XCircle className="h-3 w-3" />
+            Rejeter
           </Button>
         </div>
       </div>

--- a/features/validation-tickets/verrouillage-v2/components/TicketReadyList.tsx
+++ b/features/validation-tickets/verrouillage-v2/components/TicketReadyList.tsx
@@ -9,12 +9,13 @@ interface Props {
   tickets: TicketControleV2[];
   total: number;
   onLock: (ticketId: string) => void;
+  onReject: (ticketId: string) => void;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage: () => void;
 }
 
-export default function TicketReadyList({ tickets, total, onLock, hasNextPage, isFetchingNextPage, fetchNextPage }: Props) {
+export default function TicketReadyList({ tickets, total, onLock, onReject, hasNextPage, isFetchingNextPage, fetchNextPage }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -42,7 +43,7 @@ export default function TicketReadyList({ tickets, total, onLock, hasNextPage, i
 
       <div ref={scrollRef} className="flex flex-col gap-2 overflow-y-auto flex-1 min-h-0 pr-1">
         {tickets.map((ticket) => (
-          <TicketReadyCard key={ticket.commandeId} ticket={ticket} onLock={onLock} />
+          <TicketReadyCard key={ticket.commandeId} ticket={ticket} onLock={onLock} onReject={onReject} />
         ))}
         <div ref={bottomRef} className="flex items-center justify-center py-1 shrink-0">
           {isFetchingNextPage && <Loader2 className="h-4 w-4 animate-spin text-gray-300" />}

--- a/features/validation-tickets/verrouillage-v2/components/verification-v1-content.tsx
+++ b/features/validation-tickets/verrouillage-v2/components/verification-v1-content.tsx
@@ -6,6 +6,7 @@ import TicketReadyList from './TicketReadyList';
 import TicketLockedList from './TicketLockedList';
 import useVerrouillageV2 from '../hooks/use-verrouillage-v2';
 import TicketFilterBar from '@/components/validation-tickets/TicketFilterBar';
+import { RejectMotifDialog } from '@/components/validation-tickets/verrouillage-v2/reject-motif-dialog';
 
 export default function VerificationV1Content() {
   const {
@@ -17,6 +18,10 @@ export default function VerificationV1Content() {
     setFilters,
     livreurOptions,
     isLockingAll,
+    isRejecting,
+    rejectDialogId,
+    setRejectDialogId,
+    handleReject,
     handleLock,
     handleLockAll,
     fetchNextReady,
@@ -48,6 +53,7 @@ export default function VerificationV1Content() {
           tickets={readyTickets}
           total={totalReady}
           onLock={handleLock}
+          onReject={setRejectDialogId}
           hasNextPage={!!hasNextReady}
           isFetchingNextPage={isFetchingNextReady}
           fetchNextPage={fetchNextReady}
@@ -68,6 +74,14 @@ export default function VerificationV1Content() {
           <span className="font-semibold text-gray-900">validation finale (V2)</span> du DG.
         </p>
       </div>
+
+      <RejectMotifDialog
+        open={rejectDialogId !== null}
+        ticketId={rejectDialogId}
+        isRejecting={isRejecting}
+        onConfirm={handleReject}
+        onClose={() => setRejectDialogId(null)}
+      />
     </div>
   );
 }

--- a/features/validation-tickets/verrouillage-v2/hooks/use-verrouillage-v2-content.ts
+++ b/features/validation-tickets/verrouillage-v2/hooks/use-verrouillage-v2-content.ts
@@ -5,7 +5,7 @@ import { useQueryStates } from 'nuqs';
 import { useTicketsV1ValideQuery, useTicketsV2ValideQuery, useCreneauTicketStatsQuery } from '../queries/tickets-v2-list.query';
 import { useValiderV2Mutation, useValiderV2EnMasseMutation, useRejeterV2FraudeMutation } from '../queries/tickets-v2.mutation';
 import { useCreneauActifQuery } from '@/features/creneaux/queries/creneau.query';
-import { validationTicketFiltersConfig, validationTicketFiltersOptions } from '@/features/validation-tickets/filters/validation-tickets.filters';
+import { validationTicketFiltersConfig, validationTicketFiltersOptions, validationTicketV2ValideFiltersOptions } from '@/features/validation-tickets/filters/validation-tickets.filters';
 import { useTicketFilterOptions } from '@/features/validation-tickets/hooks/use-ticket-filter-options';
 import type { IVerrouillageParams } from '../types/tickets-v2.type';
 
@@ -13,8 +13,10 @@ export function useVerrouillageV2Content() {
   const [rejectDialogId, setRejectDialogId] = useState<string | null>(null);
   const [validatingId, setValidatingId] = useState<string | null>(null);
   const [filters, setFiltersRaw] = useQueryStates(validationTicketFiltersConfig, validationTicketFiltersOptions);
+  const [v2ValideFilters, setV2ValideFiltersRaw] = useQueryStates(validationTicketFiltersConfig, validationTicketV2ValideFiltersOptions);
 
   const setFilters = (v: typeof filters) => void setFiltersRaw(v);
+  const setV2ValideFilters = (v: typeof v2ValideFilters) => void setV2ValideFiltersRaw(v);
 
   const params = useMemo<IVerrouillageParams>(() => ({
     debut: filters.debut || undefined,
@@ -25,6 +27,15 @@ export function useVerrouillageV2Content() {
     numero: filters.numero || undefined,
   }), [filters.debut, filters.fin, filters.restaurantId, filters.livreurId, filters.search, filters.numero]);
 
+  const v2ValideParams = useMemo<IVerrouillageParams>(() => ({
+    debut: v2ValideFilters.debut || undefined,
+    fin: v2ValideFilters.fin || undefined,
+    restaurantId: v2ValideFilters.restaurantId || undefined,
+    livreurId: v2ValideFilters.livreurId || undefined,
+    search: v2ValideFilters.search || undefined,
+    numero: v2ValideFilters.numero || undefined,
+  }), [v2ValideFilters.debut, v2ValideFilters.fin, v2ValideFilters.restaurantId, v2ValideFilters.livreurId, v2ValideFilters.search, v2ValideFilters.numero]);
+
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useTicketsV1ValideQuery(params);
   const {
     data: v2ValideData,
@@ -32,7 +43,7 @@ export function useVerrouillageV2Content() {
     fetchNextPage: fetchNextV2Valide,
     hasNextPage: hasNextV2Valide,
     isFetchingNextPage: isFetchingNextV2Valide,
-  } = useTicketsV2ValideQuery(params);
+  } = useTicketsV2ValideQuery(v2ValideParams);
   const { data: creneauActif } = useCreneauActifQuery();
   const { data: ticketStats, isLoading: isStatsLoading } = useCreneauTicketStatsQuery();
   const { livreurOptions } = useTicketFilterOptions();
@@ -85,6 +96,8 @@ export function useVerrouillageV2Content() {
     isFetchingNextV2Valide,
     filters,
     setFilters,
+    v2ValideFilters,
+    setV2ValideFilters,
     livreurOptions,
     isLoading,
     fetchNextPage,

--- a/features/validation-tickets/verrouillage-v2/hooks/use-verrouillage-v2.ts
+++ b/features/validation-tickets/verrouillage-v2/hooks/use-verrouillage-v2.ts
@@ -4,12 +4,13 @@ import { useState, useMemo } from 'react';
 import { useQueryStates } from 'nuqs';
 import { IVerrouillageParams } from '../types/tickets-v2.type';
 import { useTicketsAuthentifiesQuery, useTicketsV1ValideQuery } from '../queries/tickets-v2-list.query';
-import { useValiderV1Mutation } from '../queries/tickets-v2.mutation';
+import { useValiderV1Mutation, useRejeterV2FraudeMutation } from '../queries/tickets-v2.mutation';
 import { validationTicketFiltersConfig, validationTicketFiltersOptions } from '@/features/validation-tickets/filters/validation-tickets.filters';
 import { useTicketFilterOptions } from '@/features/validation-tickets/hooks/use-ticket-filter-options';
 
 export default function useVerrouillageV2() {
   const [isLockingAll, setIsLockingAll] = useState(false);
+  const [rejectDialogId, setRejectDialogId] = useState<string | null>(null);
   const [filters, setFiltersRaw] = useQueryStates(validationTicketFiltersConfig, validationTicketFiltersOptions);
 
   const setFilters = (v: typeof filters) => void setFiltersRaw(v);
@@ -34,8 +35,12 @@ export default function useVerrouillageV2() {
   const totalLocked = lockedData?.pages[0]?.totalElements ?? 0;
 
   const { mutate: validerV1, mutateAsync: validerV1Async, isPending: isLocking } = useValiderV1Mutation();
+  const { mutate: rejeterFraude, isPending: isRejecting } = useRejeterV2FraudeMutation();
 
   const handleLock = (ticketId: string) => validerV1(ticketId);
+
+  const handleReject = (id: string, motif: string) =>
+    rejeterFraude({ id, motif }, { onSuccess: () => setRejectDialogId(null) });
 
   const handleLockAll = async () => {
     if (readyTickets.length === 0) return;
@@ -68,6 +73,10 @@ export default function useVerrouillageV2() {
     isLoadingLocked,
     isLocking,
     isLockingAll,
+    isRejecting,
+    rejectDialogId,
+    setRejectDialogId,
+    handleReject,
     fetchNextReady,
     hasNextReady,
     isFetchingNextReady,


### PR DESCRIPTION
## Contexte

Deux ajustements sur le module **validation-tickets**.

## Modifications

### 1. Filtres sur le 2ᵉ tableau de `/validation-tickets/verrouillage-v2`

Le tableau du bas (« Tickets V2 validés ») partageait les filtres du tableau du haut. Il dispose désormais de **ses propres filtres indépendants**, identiques à ceux du haut (code check, livreur, restaurant, dates).

- `validation-tickets.filters.ts` : nouvel `validationTicketV2ValideFiltersOptions` avec des `urlKeys` préfixés (`v2_*`) pour éviter toute collision d'URL avec le tableau du haut.
- `use-verrouillage-v2-content.ts` : second état de filtres (`v2ValideFilters`) + `v2ValideParams` passés à `useTicketsV2ValideQuery`.
- `verrouillage-v2-content.tsx` : `TicketFilterBar` ajoutée au-dessus du tableau du bas.

### 2. Bouton de rejet sur `/validation-tickets/verification-v1` (section de gauche)

Ajout d'un bouton **« Rejeter »** sur chaque carte de la liste « Prêts pour V1 », utilisant le **même endpoint** que le rejet de verrouillage-v2 (`rejeterTicketPourFraude`).

- `use-verrouillage-v2.ts` : mutation de rejet + état du dialog + `handleReject`.
- `verification-v1-content.tsx` : `RejectMotifDialog` monté.
- `TicketReadyList.tsx` / `TicketReadyCard.tsx` : propagation du `onReject` et bouton destructif (`commandeId`).

## Vérification

- `npx tsc --noEmit` : **0 erreur**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
